### PR TITLE
minor changes to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,8 +17,8 @@ from Wikimedia Commons.</p>
 
 <h2>Introduction</h2>
 
-<p>The <a href="http://commons.wikimedia.org/">Wikimedia
-Commons</a> <a href="http://commons.wikimedia.org/wiki/Commons:Project_scope">aims</a>
+<p>The <a href="//commons.wikimedia.org/">Wikimedia
+Commons</a> <a href="//commons.wikimedia.org/wiki/Commons:Project_scope">aims</a>
 to make available public domain and freely licensed educational media
 files for everyone. It's a beautiful thing.</p>
 
@@ -84,15 +84,15 @@ problem.</p>
 
 <p>As a next step, I might make a more flexible API. There is however
 already such a tool available as a web API, Magnus
-Manske's <a href="http://tools.wmflabs.org/magnus-toolserver/commonsapi.php">Commons
+Manske's <a href="//tools.wmflabs.org/magnus-toolserver/commonsapi.php">Commons
 API</a>, giving you access to all the metadata you might need as
 XML. There is currently some problems with the generated XML.</p>
 
 <!-- <h2>How does it work?</h2> -->
 <h2>See also</h2>
 <ul>
-<li><a href="http://commons.wikimedia.org/wiki/Commons:Machine-readable_data">Commons:Machine-readable data</a></li>
-<li><a href="http://commons.wikimedia.org/wiki/MediaWiki:Gadget-Stockphoto.js">Gadget-Stockphoto.js</a> &ndash; usecommons code is basically a Python port of this</li>
+<li><a href="//commons.wikimedia.org/wiki/Commons:Machine-readable_data">Commons:Machine-readable data</a></li>
+<li><a href="//commons.wikimedia.org/wiki/MediaWiki:Gadget-Stockphoto.js">Gadget-Stockphoto.js</a> &ndash; usecommons code is basically a Python port of this</li>
 </ul>
 
 <script type="text/javascript">


### PR DESCRIPTION
- use protocol-relative URLs for Wikimedia Commons
- replace a Toolserver URL with the new Tool Labs one
- skip a redirect
- fix a typo
